### PR TITLE
Fix websockets in iOS

### DIFF
--- a/lib/assets/javascripts/websocket_rails/websocket_rails.js
+++ b/lib/assets/javascripts/websocket_rails/websocket_rails.js
@@ -22,7 +22,7 @@ var WebSocketRails = function(url) {
   
   that.state = 'connecting';
 
-  if( typeof(WebSocket) != "function" ) {
+  if( typeof(WebSocket) != "function" && typeof(WebSocket) != "object" ) {
     var conn = new WebSocketRails.HttpConnection(url);
   } else {
     var conn = new WebSocketRails.WebSocketConnection(url);


### PR DESCRIPTION
typeof(WebSocket) returns 'object' on my iPad, this pull request fixes websockets on my iPad and doesn't break them in Chrome, I haven't tested with other browsers.
