### PR TITLE
Use websocket-rails with websockets over ssl

### DIFF
--- a/lib/assets/javascripts/websocket_rails/websocket_connection.js.coffee
+++ b/lib/assets/javascripts/websocket_rails/websocket_connection.js.coffee
@@ -4,7 +4,8 @@ WebSocket Interface for the WebSocketRails client.
 class WebSocketRails.WebSocketConnection
 
   constructor: (@url,@dispatcher) ->
-    @_conn           = new WebSocket("ws://#{@url}")
+    @url             = "ws://#{@url}" unless @url.match(/^wss?:\/\//)
+    @_conn           = new WebSocket(@url)
     @_conn.onmessage = @on_message
     @_conn.onclose   = @on_close
 


### PR DESCRIPTION
I'm using websockets over ssl in production so I need to be able to do wss://my-sweet-app.com/websocket instead of ws://my-sweet-app.com/websocket

This pull requests allows the optional inclusion of ws:// or wss:// at the beginning of the url when creating a dispatcher. If they aren't included it will append ws:// as before.
