### PR TITLE
Communicate other worker type (such delayed job) to ws itself

### DIFF
--- a/lib/rails/config/routes.rb
+++ b/lib/rails/config/routes.rb
@@ -1,3 +1,7 @@
 Rails.application.routes.draw do
-  match "/websocket", :to => WebsocketRails::ConnectionManager.new
-end
+  if WebsocketRails.stage?
+    match "/websocket", :to => WebsocketRails::ConnectionManager.new
+    #reject all path after
+    #match ':controller/:action/*any' , :to => WebsocketRails::WtfHandler.new ?  
+  end
+end 

--- a/lib/websocket-rails.rb
+++ b/lib/websocket-rails.rb
@@ -25,6 +25,9 @@ module WebsocketRails
   end
 end
 
+require 'websocket_rails/stager'
+require 'websocket_rails/redis'
+
 require 'websocket_rails/engine'
 require 'websocket_rails/logging'
 require 'websocket_rails/connection_manager'

--- a/lib/websocket_rails/engine.rb
+++ b/lib/websocket_rails/engine.rb
@@ -3,10 +3,18 @@ module WebsocketRails
   class Engine < Rails::Engine
 
     config.autoload_paths += [File.expand_path("../../lib", __FILE__)]
-
+    config.app_middleware.insert_before(ActionDispatch::BestStandardsSupport, WebsocketRails::Stager)
+    config.app_middleware.insert_after(WebsocketRails::Stager, WebsocketRails::Redis::RedisSubscriber)
+    
     paths["app"] << "lib/rails/app"
     paths["app/controllers"] << "lib/rails/app/controllers"
-    paths["config/routes"]   << "lib/rails/config/routes.rb"
-
+    paths["config/routes"] << "lib/rails/config/routes.rb"
+    
+    initializer "overiding router" do |app|
+      ws_route = File.expand_path File.dirname(__FILE__)+'/../rails/config/routes.rb';
+      app.routes_reloader.paths.delete_if{ |path| path.include?(ws_route) }
+      app.routes_reloader.paths.prepend(ws_route)
+    end
+    
   end
 end

--- a/lib/websocket_rails/redis.rb
+++ b/lib/websocket_rails/redis.rb
@@ -1,0 +1,67 @@
+module WebsocketRails
+  module Redis
+    def self.publish channel, event, data={}, options={}
+      redis_obect = {
+        :channel => channel,
+        :event => event,
+        :data => data,
+        :options => options
+      }
+      jsn = redis_obect.to_json
+    end
+    
+    
+    def self.server
+      ::Redis.new(:host => '127.0.0.1', :post => 6379)
+    end
+    
+    class << self
+       def [](channel)
+          ChannelManager.new channel
+      end
+    end
+    class ChannelManager
+      attr_reader :name
+      def initialize channel
+        @name = channel
+      end
+      def trigger(event_name,data={},options={})
+        
+        redis_obect = {
+          :channel => name,
+          :event => event_name,
+          :data => data,
+          :options => options
+        }
+        WebsocketRails::Redis.server.publish 'ws', redis_obect.to_json
+      end
+    end
+    
+    
+    class RedisSubscriber
+      def initialize app
+        @app = app
+      end
+      
+      def call env
+        start_thread  if WebsocketRails.stage?
+        @app.call(env)
+      end
+      
+      def start_thread
+         Thread.new do
+            WebsocketRails::Redis.server.subscribe('ws') do |on|
+          
+              on.message do |chan, msg|
+               object = JSON.parse(msg, :symbolize_names => true )
+               puts "sending message: #{object[:data]}"
+
+               WebsocketRails[object[:channel].to_sym].trigger object[:event], object[:data], object[:options]
+              end
+            end
+          end 
+      end
+    end
+    
+  end
+end

--- a/lib/websocket_rails/stager.rb
+++ b/lib/websocket_rails/stager.rb
@@ -1,0 +1,23 @@
+module WebsocketRails
+  def self.stage?
+    @stage
+  end
+  def self.stage=(val)
+    @stage = val
+  end
+  class Stager
+    def initialize app
+      @app = app
+      WebsocketRails.stage = (ENV['WS_STAGE'] == 1.to_s ? true : false) 
+      #rotate route 
+    end
+    def call env
+      @app.call(env)
+    end
+  end 
+  class WtfHandler 
+    def initialize
+      
+    end
+  end
+end


### PR DESCRIPTION
your plugin completely awesome, but i got problem since my app  have other process type, beside the web process, i have delayed_job.., i want my delayed job able to trigger the channel subscribed by client which connected by ws on different port with delayed_job, so i think. we can save the data to redis, and beside the websocket we register Thread to subscribed the redis when value stored by key 'ws' , and then trigger the ws which on same port with theard registered... , 

and now we can triggered the channel like this

```
WebsocketRails::Redis[:post].trigger 'new', Post.last
```

i was inspired by  [Jesse Dearing](https://github.com/JesseDearing) on his [post](http://jessedearing.com/nodes/4-pubsubbin-with-redis-eventmachine-and-websockets)

i definitely zero about ruby , or rails.. sorry for my bad code.  i wish, i can get more by you. hehehe ..
