### PR TITLE
client_disconnected event fires twice on the server (Issue 24) FIXED

### DIFF
--- a/lib/websocket_rails/connection_adapters.rb
+++ b/lib/websocket_rails/connection_adapters.rb
@@ -52,6 +52,7 @@ module WebsocketRails
       end
 
       def on_close(data=nil)
+        @ping_timer.cancel
         dispatch Event.new_on_close( self, data )
         close_connection
       end


### PR DESCRIPTION
Fixed Issue https://github.com/DanKnox/websocket-rails/issues/24
