### PR TITLE
Unsubscribe connection from channels on close_connection

### DIFF
--- a/lib/websocket_rails/channel.rb
+++ b/lib/websocket_rails/channel.rb
@@ -16,6 +16,12 @@ module WebsocketRails
       @subscribers << connection
     end
 
+    def unsubscribe(connection)
+      return unless @subscribers.include? connection
+      log "#{connection} unsubscribed from channel #{name}"
+      @subscribers.delete connection
+    end
+
     def trigger(event_name,data={},options={})
       options.merge! :channel => name
       options[:data] = data

--- a/lib/websocket_rails/channel_manager.rb
+++ b/lib/websocket_rails/channel_manager.rb
@@ -26,5 +26,11 @@ module WebsocketRails
       @channels[channel] ||= Channel.new channel
     end
 
+    def unsubscribe(connection)
+      @channels.each do |channel_name, channel|
+        channel.unsubscribe(connection)
+      end
+    end
+
   end
 end

--- a/lib/websocket_rails/connection_manager.rb
+++ b/lib/websocket_rails/connection_manager.rb
@@ -76,6 +76,7 @@ module WebsocketRails
     end
 
     def close_connection(connection)
+      WebsocketRails.channel_manager.unsubscribe connection
       connections.delete connection
       log "Connection closed: #{connection}"
       connection = nil

--- a/spec/integration/connection_manager_spec.rb
+++ b/spec/integration/connection_manager_spec.rb
@@ -99,6 +99,13 @@ module WebsocketRails
             @server.call( env )
             socket.on_close
           end
+
+          it "should unsubscribe from channels" do
+            channel = WebsocketRails[:test_chan]
+            @server.call( env )
+            channel.should_receive(:unsubscribe).with(socket)
+            socket.on_close
+          end
         end
       end
     end

--- a/spec/unit/channel_manager_spec.rb
+++ b/spec/unit/channel_manager_spec.rb
@@ -25,5 +25,13 @@ module WebsocketRails
       end
     end
 
+    describe "unsubscribe" do
+      it "should unsubscribe connection from all channels" do
+        subject[:awesome_channel].should_receive(:unsubscribe).with(:some_connection)
+        subject[:awesome_channel]
+        subject.unsubscribe(:some_connection)
+      end
+    end
+
   end
 end

--- a/spec/unit/channel_spec.rb
+++ b/spec/unit/channel_spec.rb
@@ -21,6 +21,19 @@ module WebsocketRails
       end
     end
 
+    describe "#unsubscribe" do
+      it "should remove connection from subscriber pool" do
+        subject.subscribe connection
+        subject.unsubscribe connection
+        subject.subscribers.include?(connection).should be_false
+      end
+
+      it "should do nothing if connection is not subscribed to channel" do
+        subject.unsubscribe connection
+        subject.subscribers.include?(connection).should be_false
+      end
+    end
+
     describe "#trigger" do
       it "should create a new event and trigger it on all subscribers" do
         event = double('event').as_null_object


### PR DESCRIPTION
I had performance issue in my project - when i open a web-page where users subscribes to some websocket channel and press refresh several times, Channel.subscribers start to grow. Then when i send server message to channel it takes a lot of time to notify all subscribers which are already disconnected.
