### PR TITLE
Bug prevents handling of internal event under Rails

### DIFF
--- a/lib/websocket_rails/controller_factory.rb
+++ b/lib/websocket_rails/controller_factory.rb
@@ -60,10 +60,12 @@ module WebsocketRails
     # while in the development environment.
     def reload!(controller)
       return unless defined?(Rails) and Rails.env.development?
-
-      class_name = controller.name
-      filename = class_name.underscore
-      load "#{filename}.rb"
+      # we don't reload our own controller as we assume it provide as 'library'
+      unless controller == WebsocketRails::InternalController
+        class_name = controller.name
+        filename = class_name.underscore
+        load "#{filename}.rb"
+      end
     end
 
   end

--- a/spec/unit/controller_factory_spec.rb
+++ b/spec/unit/controller_factory_spec.rb
@@ -31,6 +31,19 @@ module WebsocketRails
     end
 
     describe "#new_for_event" do
+
+      context "when Rails is defined and env is set to development" do
+
+        it "creates and returns a controller instance of the InternalController" do
+          rails_env = double(:rails_env)
+          Rails.stub(:env).and_return rails_env
+          rails_env.stub(:development?).and_return true
+          controller = subject.new_for_event(event, InternalController)
+          controller.class.should == InternalController
+        end
+
+      end
+
       it "creates and returns a new controller instance" do
         controller = subject.new_for_event(event, TestController)
         controller.class.should == TestController


### PR DESCRIPTION
There is a bug in `ControllerFactory#reload!` that prevents the handling of internal event when Rails is running in development environment.

The code will try to reload files named `name_of_the_controller.rb`, but as there is no file called `internal_controller.rb`, it will fail when dealing with internal events.

I simply added an unless statement that prevents the reloading of `InternalController`. 

Also added a test to `controller_factory_spec.rb` to verify the code. Also I have the same patch running in a dev version of a Rails app of mine and it works. 
