### PR TITLE
use `Rails.configuration.cache_classes` instead of `Rails.env.development?` when reloading controllers

### DIFF
--- a/lib/websocket_rails/controller_factory.rb
+++ b/lib/websocket_rails/controller_factory.rb
@@ -59,7 +59,7 @@ module WebsocketRails
     # Reloads the controller class to pick up code changes
     # while in the development environment.
     def reload!(controller)
-      return unless defined?(Rails) and Rails.env.development?
+      return unless defined?(Rails) and !Rails.configuration.cache_classes
 
       class_name = controller.name
       filename = class_name.underscore


### PR DESCRIPTION
Because running in dev w/ cache classes on breaks if you try to reload.

Besides, this code is concerned with class caching and reloading, so we should base the logic on that as opposed to the assumption that the rails environment controls caching.
