### PR TITLE
Allow custom URL parameter for http_connection

### DIFF
--- a/lib/assets/javascripts/websocket_rails/http_connection.js.coffee
+++ b/lib/assets/javascripts/websocket_rails/http_connection.js.coffee
@@ -21,11 +21,12 @@ class WebSocketRails.HttpConnection
     xmlhttp
 
   constructor: (@url, @dispatcher) ->
+    @_url          = @url
     @_conn         = @createXMLHttpObject()
     @last_pos      = 0
     @message_queue = []
     @_conn.onreadystatechange = @parse_stream
-    @_conn.open "GET", "/websocket", true
+    @_conn.open "GET", @_url, true
     @_conn.send()
 
   parse_stream: =>
@@ -43,7 +44,7 @@ class WebSocketRails.HttpConnection
       @post_data @dispatcher.connection_id, event.serialize()
 
   post_data: (connection_id, payload) ->
-    $.ajax "/websocket",
+    $.ajax @_url,
       type: 'POST'
       data:
         client_id: connection_id

--- a/lib/assets/javascripts/websocket_rails/websocket_rails.js.coffee
+++ b/lib/assets/javascripts/websocket_rails/websocket_rails.js.coffee
@@ -2,7 +2,7 @@
 WebsocketRails JavaScript Client
 
 Setting up the dispatcher:
-  var dispatcher = new WebSocketRails('localhost:3000');
+  var dispatcher = new WebSocketRails('localhost:3000/websocket');
   dispatcher.on_open = function() {
     // trigger a server event immediately after opening connection
     dispatcher.trigger('new_user',{user_name: 'guest'});


### PR DESCRIPTION
The URL was hardcoded in the http_connection class, which is not the case for websocket_connection. Now the URL parameter used in the constructor is used for both connection methods.
