### PR TITLE
Load Faye::WebSocket thin adapter after require

### DIFF
--- a/lib/websocket_rails/connection_manager.rb
+++ b/lib/websocket_rails/connection_manager.rb
@@ -2,6 +2,8 @@ require 'faye/websocket'
 require 'rack'
 require 'thin'
 
+Faye::WebSocket.load_adapter('thin')
+
 module WebsocketRails
   # The +ConnectionManager+ class implements the core Rack application that handles
   # incoming WebSocket connections.


### PR DESCRIPTION
Call `Faye::WebSocket.load_adapter('thin')` in `connection_manager.rb` to fix 

> Error during WebSocket handshake: 'Upgrade' header is missing 

See issue #85 for details
