### PR TITLE
fix for the "missing constant WebsocketRails::InternalEvents::InternalController" bug when reloading the routes

### DIFF
--- a/lib/websocket_rails/base_controller.rb
+++ b/lib/websocket_rails/base_controller.rb
@@ -21,7 +21,7 @@ module WebsocketRails
     # Tell Rails that BaseController and children can be reloaded when in
     # the Development environment.
     def self.inherited(controller)
-      unloadable controller
+      unloadable controller unless controller.name == "WebsocketRails::InternalController"
     end
 
     # Add observers to specific events or the controller in general. This functionality is similar


### PR DESCRIPTION
I don't know how to test that but it works for me. Since the InternalController inherits from the BaseController and the BaseController marks the inheriting controller as unloadable the InternalController will get unloaded by Rails.
