### PR TITLE
Fix for newlines being outputted in the log even if the message being logged is below the current config.log_level

### DIFF
--- a/lib/websocket_rails/logging.rb
+++ b/lib/websocket_rails/logging.rb
@@ -46,7 +46,6 @@ module WebsocketRails
       message.chomp.split("\n").each do |line|
         logger.send(level, wrap(level, self, line, options || {}))
       end
-      logger << "\n"
     end
 
     def log_event_start(event)


### PR DESCRIPTION
When log level is at error, a new line was being logged for every info logger message. Ref #146
