### PR TITLE
Foreman support

### DIFF
--- a/lib/generators/websocket_rails/install/templates/websocket_rails.rb
+++ b/lib/generators/websocket_rails/install/templates/websocket_rails.rb
@@ -22,6 +22,9 @@ WebsocketRails.setup do |config|
   # * Requires Redis.
   config.synchronize = false
 
+  # Prevent Thin from daemonizing (default is true)
+  # config.daemonize = false
+
   # Uncomment and edit to point to a different redis instance.
   # Will not be used unless standalone or synchronization mode
   # is enabled.

--- a/lib/rails/tasks/websocket_rails.tasks
+++ b/lib/rails/tasks/websocket_rails.tasks
@@ -9,8 +9,12 @@ namespace :websocket_rails do
 
     warn_if_standalone_not_enabled!
 
-    fork do
-      Thin::Controllers::Controller.new(options).start
+    if options[:daemonize]
+      fork do
+        Thin::Controllers::Controller.new(options).start
+      end
+    else
+        Thin::Controllers::Controller.new(options).start
     end
 
     puts "Websocket Rails Standalone Server listening on port #{options[:port]}"

--- a/lib/websocket_rails/configuration.rb
+++ b/lib/websocket_rails/configuration.rb
@@ -81,6 +81,14 @@ module WebsocketRails
       @log_internal_events = value
     end
 
+    def daemonize?
+      @daemonize.nil? ? true : @daemonize
+    end
+
+    def daemonize=(value)
+      @daemonize = value
+    end
+
     def synchronize
       @synchronize ||= false
     end
@@ -133,7 +141,7 @@ module WebsocketRails
         :tag => 'websocket_rails',
         :rackup => "#{Rails.root}/config.ru",
         :threaded => false,
-        :daemonize => true,
+        :daemonize => daemonize?,
         :dirname => Rails.root,
         :max_persistent_conns => 1024,
         :max_conns => 1024


### PR DESCRIPTION
closes #86

Adding `config.daemonize = false` in your websocket_rails config file will prevent thin from forking into the background.
