### PR TITLE
Added a possibility to set channel success and failure callbacks on subs...

### DIFF
--- a/lib/assets/javascripts/websocket_rails/channel.js.coffee
+++ b/lib/assets/javascripts/websocket_rails/channel.js.coffee
@@ -9,7 +9,7 @@ For instance:
 ###
 class WebSocketRails.Channel
 
-  constructor: (@name, @_dispatcher, @is_private) ->
+  constructor: (@name, @_dispatcher, @is_private, @on_success, @on_failure) ->
     if @is_private
       event_name = 'websocket_rails.subscribe_private'
     else
@@ -55,9 +55,9 @@ class WebSocketRails.Channel
         callback message
 
   # using this method because @on_success will not be defined when the constructor is executed
-  _success_launcher: (data) ->
+  _success_launcher: (data) =>
     @on_success(data) if @on_success?
 
   # using this method because @on_failure will not be defined when the constructor is executed
-  _failure_launcher: (data) ->
+  _failure_launcher: (data) =>
     @on_failure(data) if @on_failure?

--- a/lib/assets/javascripts/websocket_rails/websocket_rails.js.coffee
+++ b/lib/assets/javascripts/websocket_rails/websocket_rails.js.coffee
@@ -102,17 +102,17 @@ class @WebSocketRails
     for callback in @callbacks[event.name]
       callback event.data
 
-  subscribe: (channel_name) =>
+  subscribe: (channel_name, success_callback, failure_callback) =>
     unless @channels[channel_name]?
-      channel = new WebSocketRails.Channel channel_name, @
+      channel = new WebSocketRails.Channel channel_name, @, false, success_callback, failure_callback
       @channels[channel_name] = channel
       channel
     else
       @channels[channel_name]
 
-  subscribe_private: (channel_name) =>
+  subscribe_private: (channel_name, success_callback, failure_callback) =>
     unless @channels[channel_name]?
-      channel = new WebSocketRails.Channel channel_name, @, true
+      channel = new WebSocketRails.Channel channel_name, @, true, success_callback, failure_callback
       @channels[channel_name] = channel
       channel
     else


### PR DESCRIPTION
I experienced a strange problem, when I deployed my app to production and had to switch to standalone server mode with Redis. For some reason, I was unable to handle channel events using the Javascript API, although I had set handler functions with `channel.bind` function and everything worked with Thin in my development environment. The bug seemed random, as every now and then everything worked as supposed to.

After some digging, I found out that the problem must be related to the way I bind the handlers:

``` coffeescript
@dispatcher.on_open = @bindEvents

  bindEvents: =>
    channel = @dispatcher.subscribe_private @channelId
    channel.bind 'message', @handleEvents
```

If this operation was performed too quickly after dispatcher was opened, the problem would occur. A problem could be bypassed to a degree by adding a delay to bindEvents call.

A better solution would be to bind the channel events only after the channel has been successfully set up, using the on_success callback:

``` coffeescript
  bindEvents: =>
    channel = @dispatcher.subscribe_private @channelId, =>
      channel.bind 'message', @handleEvents
```

Going through channels.js.coffee, it seemed that on_success and on_failure callbacks were completely useless, as they are only called in the constructor for the subscribe event, but could be only set after the object has been constructed. So I modified the classes to allow passing the callbacks on @dispatcher.subscribe (channel construction). This solved my problem.

I still don't know what's the reason why this only occurs in standalone server mode, though.
