### PR TITLE
Add verification of parsing results in Event.

### DIFF
--- a/lib/websocket_rails/event.rb
+++ b/lib/websocket_rails/event.rb
@@ -71,6 +71,11 @@ module WebsocketRails
       case encoded_data
       when String
         event_name, data = JSON.parse encoded_data
+
+        unless event_name.is_a?(String) and data.is_a?(Hash)
+          raise UnknownDataType
+        end
+
         data = data.merge(:connection => connection).with_indifferent_access
         Event.new event_name, data
         # when Array


### PR DESCRIPTION
Prevent the server from crashing when someone passes valid, but badly
formatted JSON.

Sending a bad JSON string to the server can bring it down. For instance, if
<code>encoded_data == "[[\"websocket_rails.pong\", {}]]"</code>

A NoMethodError exception is raised and the server goes down.
