### PR TITLE
Add verification of parsing results in Event.

### DIFF
--- a/lib/websocket_rails/event.rb
+++ b/lib/websocket_rails/event.rb
@@ -71,6 +71,11 @@ module WebsocketRails
       case encoded_data
       when String
         event_name, data = JSON.parse encoded_data
+
+        unless event_name.is_a?(String) && data.is_a?(Hash)
+          raise UnknownDataType
+        end
+
         data = data.merge(:connection => connection).with_indifferent_access
         Event.new event_name, data
         # when Array

--- a/spec/unit/event_spec.rb
+++ b/spec/unit/event_spec.rb
@@ -9,6 +9,7 @@ module WebsocketRails
     let(:channel_encoded_message_string) { '["new_message",{"id":"1234","channel":"awesome_channel","user_id":null,"data":"this is a message","success":null,"result":null,"token":null,"server_token":"1234"}]' }
     let(:synchronizable_encoded_message) { '["new_message",{"id":"1234","data":{"message":"this is a message"},"server_token":"1234"}]' }
     let(:connection) { double('connection') }
+    let(:wrongly_encoded_message) { '["new_message",[{"id":"1234","data":{"message":"this is a message"}}]]' }
 
     before { connection.stub!(:id).and_return(1) }
 
@@ -29,6 +30,13 @@ module WebsocketRails
           event.namespace.should == [:global,:product]
           event.name.should == :new_message
           event.data[:message].should == 'this is a message'
+        end
+      end
+
+      context "invalid messages" do
+        it "should return an invalid event if data is wrongly encoded" do
+          event = Event.new_from_json( wrongly_encoded_message, connection )
+          event.is_invalid?.should be_true
         end
       end
     end


### PR DESCRIPTION
Prevent the server from crashing when someone passes valid, but
wrongly formatted JSON.

Sending a bad JSON string to the server can bring it down with a
NoMethodError exception. For instance:
<code>encoded_data == "[[\"websocket_rails.pong\", {}]]"</code>

Added the spec to test for the fix. It fails without the fix, but passes after.
I think it should be enough. :D
