### PR TITLE
Added ping interval configuration.

### DIFF
--- a/lib/websocket_rails/configuration.rb
+++ b/lib/websocket_rails/configuration.rb
@@ -157,5 +157,13 @@ module WebsocketRails
       }
     end
 
+    def default_ping_interval
+      @default_ping_interval ||= 10
+    end
+
+    def default_ping_interval=(interval)
+      @default_ping_interval = interval.to_i
+    end
+
   end
 end

--- a/lib/websocket_rails/connection_adapters.rb
+++ b/lib/websocket_rails/connection_adapters.rb
@@ -58,7 +58,7 @@ module WebsocketRails
       end
 
       def on_close(data=nil)
-        @ping_timer.cancel
+        @ping_timer.try(:cancel)
         dispatch Event.new_on_close( self, data )
         close_connection
       end
@@ -136,6 +136,16 @@ module WebsocketRails
          end
       end
 
+      def ping_interval
+        @ping_interval ||= WebsocketRails.config.default_ping_interval
+      end
+
+      def ping_interval=(interval)
+        @ping_interval = interval.to_i
+        @ping_timer.try(:cancel)
+        start_ping_timer
+      end
+
       private
 
       def dispatch(event)
@@ -164,14 +174,18 @@ module WebsocketRails
 
       def start_ping_timer
         @pong = true
-        @ping_timer = EM::PeriodicTimer.new(10) do
-          if pong == true
-            self.pong = false
-            ping = Event.new_on_ping self
-            trigger ping
-          else
-            @ping_timer.cancel
-            on_error
+
+        # Set negative interval to nil to deactivate periodic pings
+        if ping_interval > 0
+          @ping_timer = EM::PeriodicTimer.new(ping_interval) do
+            if pong == true
+              self.pong = false
+              ping = Event.new_on_ping self
+              trigger ping
+            else
+              @ping_timer.cancel
+              on_error
+            end
           end
         end
       end

--- a/spec/unit/connection_adapters_spec.rb
+++ b/spec/unit/connection_adapters_spec.rb
@@ -29,6 +29,34 @@ module WebsocketRails
         adapter = ConnectionAdapters.establish_connection(mock_request, @dispatcher)
         adapter.class.should == ConnectionAdapters::Test
       end
+
+    end
+
+    context "ping_timer" do
+      it "should set a ping_timer to the default 10 seconds value" do
+        adapter = ConnectionAdapters.establish_connection(mock_request, @dispatcher)
+        adapter.instance_variable_get(:@ping_timer).interval.should == 10
+      end
+
+      it "should change the ping interval after creation" do
+        adapter = ConnectionAdapters.establish_connection(mock_request, @dispatcher)
+        adapter.instance_variable_get(:@ping_timer).interval.should == 10
+
+        adapter.ping_interval = 50
+        adapter.instance_variable_get(:@ping_timer).interval.should == 50
+      end
+
+      it "should not set a ping_timer if ping_interval < 1" do
+        WebsocketRails.config.default_ping_interval = 0
+        adapter = ConnectionAdapters.establish_connection(mock_request, @dispatcher)
+        adapter.instance_variable_get(:@ping_timer).should == nil
+      end
+
+      it "should set the ping_timer to the value in the config" do
+        WebsocketRails.config.default_ping_interval = 45
+        adapter = ConnectionAdapters.establish_connection(mock_request, @dispatcher)
+        adapter.instance_variable_get(:@ping_timer).interval.should == 45
+      end
     end
 
   end


### PR DESCRIPTION
This adds a new config: default_ping_interval

It also adds the option to override this value in the ConnectionAdapter, allowing the ping interval to be set on a per-client basis, while keeping the same 10 second default. Ping can also be disabled altogether by defining a value < 1.

This can be useful in use-cases where you have different clients (desktops and mobiles) where battery might be an issue for some, while delay might be important to others.

Anyway, this is useful to me, but I'm not sure about others. Feel free to discard if you think it's too great a change for a small use-case. :D
