### PR TITLE
Channel: using attributes directly.

### DIFF
--- a/lib/websocket_rails/channel.rb
+++ b/lib/websocket_rails/channel.rb
@@ -14,7 +14,7 @@ module WebsocketRails
     end
 
     def subscribe(connection)
-      info "#{connection} subscribed to channel #{name}"
+      info "#{connection} subscribed to channel #{@name}"
       trigger 'subscriber_join', connection.user if config.broadcast_subscriber_events?
       @subscribers << connection
       send_token connection
@@ -22,24 +22,24 @@ module WebsocketRails
 
     def unsubscribe(connection)
       return unless @subscribers.include? connection
-      info "#{connection} unsubscribed from channel #{name}"
+      info "#{connection} unsubscribed from channel #{@name}"
       @subscribers.delete connection
       trigger 'subscriber_part', connection.user if config.broadcast_subscriber_events?
     end
 
     def trigger(event_name,data={},options={})
-      options.merge! :channel => name, :token => token
+      options.merge! :channel => @name, :token => token
       options[:data] = data
 
       event = Event.new event_name, options
 
-      info "[#{name}] #{event.data.inspect}"
+      info "[#{@name}] #{event.data.inspect}"
       send_data event
     end
 
     def trigger_event(event)
       return if event.token != token
-      info "[#{name}] #{event.data.inspect}"
+      info "[#{@name}] #{event.data.inspect}"
       send_data event
     end
 
@@ -83,7 +83,7 @@ module WebsocketRails
         Synchronization.publish event
       end
 
-      subscribers.each do |subscriber|
+      @subscribers.each do |subscriber|
         subscriber.trigger event
       end
     end


### PR DESCRIPTION
Hello! This small pull-request contains fix for attribute usage in `Channel` class.
Inside a class, it is better and faster to use attributes directly, instead of permanent calls `attr_reader` generated methods (`self.name` or `self.subscribers`).
