### PR TITLE
Channel Filtering

### DIFF
--- a/lib/websocket_rails/base_controller.rb
+++ b/lib/websocket_rails/base_controller.rb
@@ -45,6 +45,27 @@ module WebsocketRails
       end
     end
 
+    # Tell the dispatcher to use channel filtering on specific channels.
+    # If supplied, the :catch_all => :method will be processed for every
+    # event that comes into the channel(s).
+    #
+    #
+    # Example:
+    # To process events based upon the event_name inside :channel_one
+    #
+    #  filter_for_channels :channel_one
+    #
+    # To process events based upon the event_name and a catch all
+    #
+    #  filter_for_channels :channel_one, :catch_all => :logger_method
+    #
+    def self.filter_for_channels(*channels)
+      options = channels.last.is_a?(Hash) ? channels.pop : {}
+      channels.each do |channel|
+        WebsocketRails.filtered_channels[channel] = options[:catch_all].nil? ? self : [self, options[:catch_all]]
+      end
+    end
+
     # Provides direct access to the connection object for the client that
     # initiated the event that is currently being executed.
     def connection
@@ -99,6 +120,10 @@ module WebsocketRails
 
     def deny_channel(data=nil)
       trigger_failure data
+    end
+
+    def stop_event_propagation!
+      event.propagate = false
     end
 
     # Sends a message to the client that initiated the current event being executed. Messages

--- a/lib/websocket_rails/channel.rb
+++ b/lib/websocket_rails/channel.rb
@@ -3,7 +3,7 @@ module WebsocketRails
 
     include Logging
 
-    delegate :config, :channel_tokens, :channel_manager, :to => WebsocketRails
+    delegate :config, :channel_tokens, :channel_manager, :filtered_channels, :to => WebsocketRails
 
     attr_reader :name, :subscribers
 
@@ -50,6 +50,10 @@ module WebsocketRails
       @private = true
     end
 
+    def filter_with(controller, catch_all=nil)
+      filtered_channels[@name] = catch_all.nil? ? controller : [controller, catch_all]
+    end
+
     def is_private?
       @private
     end
@@ -79,6 +83,7 @@ module WebsocketRails
     end
 
     def send_data(event)
+      return unless event.should_propagate?
       if WebsocketRails.synchronize? && event.server_token.nil?
         Synchronization.publish event
       end

--- a/lib/websocket_rails/channel_manager.rb
+++ b/lib/websocket_rails/channel_manager.rb
@@ -16,14 +16,19 @@ module WebsocketRails
       channel_manager.channel_tokens
     end
 
+    def filtered_channels
+      channel_manager.filtered_channels
+    end
+
   end
 
   class ChannelManager
 
-    attr_reader :channels
+    attr_reader :channels, :filtered_channels
 
     def initialize
       @channels = {}.with_indifferent_access
+      @filtered_channels = {}.with_indifferent_access
     end
 
     def channel_tokens

--- a/lib/websocket_rails/dispatcher.rb
+++ b/lib/websocket_rails/dispatcher.rb
@@ -5,6 +5,8 @@ module WebsocketRails
 
     attr_reader :event_map, :connection_manager, :controller_factory
 
+    delegate :filtered_channels, to: WebsocketRails
+
     def initialize(connection_manager)
       @connection_manager = connection_manager
       @controller_factory = ControllerFactory.new(self)
@@ -25,7 +27,7 @@ module WebsocketRails
       return if event.is_invalid?
 
       if event.is_channel?
-        WebsocketRails[event.channel].trigger_event event
+        filter_channel(event)
       else
         reload_event_map! unless event.is_internal?
         route event
@@ -71,6 +73,31 @@ module WebsocketRails
           end
         end
       end
+      execute actions
+    end
+
+    def filter_channel(event)
+      actions = []
+      actions << Fiber.new do
+        begin
+          log_event(event) do
+            controller_class, catch_all = filtered_channels[event.channel]
+
+            controller = controller_factory.new_for_event(event, controller_class, event.name)
+            # send to the method of the event name
+            # silently skip routing to the controller on event.name if it doesnt respond
+            controller.process_action(event.name, event) if controller.respond_to?(event.name)
+            # send to our defined catch all method
+            controller.process_action(catch_all, event) if catch_all
+
+          end
+        rescue Exception => ex
+          event.success = false
+          event.data = extract_exception_data ex
+          event.trigger
+        end
+      end
+      actions << Fiber.new{ WebsocketRails[event.channel].trigger_event(event) }
       execute actions
     end
 

--- a/lib/websocket_rails/event.rb
+++ b/lib/websocket_rails/event.rb
@@ -100,7 +100,7 @@ module WebsocketRails
 
     attr_reader :id, :name, :connection, :namespace, :channel, :user_id, :token
 
-    attr_accessor :data, :result, :success, :server_token
+    attr_accessor :data, :result, :success, :server_token, :propagate
 
     def initialize(event_name, options={})
       case event_name
@@ -118,6 +118,7 @@ module WebsocketRails
       @connection   = options[:connection]
       @server_token = options[:server_token]
       @user_id      = options[:user_id]
+      @propagate    = options[:propagate].nil? ? true : options[:propagate]
       @namespace    = validate_namespace( options[:namespace] || namespace )
     end
 
@@ -155,6 +156,10 @@ module WebsocketRails
 
     def is_internal?
       namespace.include?(:websocket_rails)
+    end
+
+    def should_propagate?
+      @propagate
     end
 
     def trigger

--- a/spec/unit/dispatcher_spec.rb
+++ b/spec/unit/dispatcher_spec.rb
@@ -23,7 +23,7 @@ end
 module WebsocketRails
 
   class EventTarget
-    attr_reader :_event, :_dispatcher, :test_method
+    attr_reader :_event, :_dispatcher, :test_method, :catch_all_method
   end
 
   describe Dispatcher do
@@ -76,12 +76,39 @@ module WebsocketRails
       end
 
       context "channel events" do
+        before do
+          subject.stub(:filtered_channels).and_return({})
+        end
         it "should forward the data to the correct channel" do
           event = Event.new 'test', :data => 'data', :channel => :awesome_channel
           channel = double('channel')
           channel.should_receive(:trigger_event).with(event)
           WebsocketRails.should_receive(:[]).with(:awesome_channel).and_return(channel)
           subject.dispatch event
+        end
+      end
+
+      context "filtered channel events" do
+        before do
+          subject.stub(:filtered_channels).and_return({:awesome_channel => EventTarget})
+        end
+        it "should execute the correct method on the target class" do
+          event = Event.new 'test_method', :data => 'some data', :channel => :awesome_channel
+          EventTarget.any_instance.should_receive(:process_action).with(:test_method, event)
+          subject.dispatch(event)
+        end
+      end
+
+      context "filtered channel catch all events" do
+        before do
+          subject.stub(:filtered_channels).and_return({:awesome_channel => [EventTarget, :catch_all_method]})
+        end
+
+        it "should execute the correct method on the target class" do
+          event = Event.new 'test_method', :data => 'some data', :channel => :awesome_channel
+          EventTarget.any_instance.should_receive(:process_action).with(:test_method, event)
+          EventTarget.any_instance.should_receive(:process_action).with(:catch_all_method, event)
+          subject.dispatch(event)
         end
       end
 

--- a/spec/unit/event_spec.rb
+++ b/spec/unit/event_spec.rb
@@ -11,7 +11,7 @@ module WebsocketRails
     let(:connection) { double('connection') }
     let(:wrongly_encoded_message) { '["new_message",[{"id":"1234","data":{"message":"this is a message"}}]]' }
 
-    before { connection.stub!(:id).and_return(1) }
+    before { connection.stub(:id).and_return(1) }
 
     describe ".new_from_json" do
       context "messages in the global namespace" do
@@ -97,7 +97,7 @@ module WebsocketRails
       end
 
       it "should not raise an error if the channel name cannot be symbolized" do
-        expect { Event.new "event", :data => {}, :connection => connection, :channel => 5 }.to_not raise_error(NoMethodError)
+        expect { Event.new "event", :data => {}, :connection => connection, :channel => 5 }.to_not raise_error
         event = Event.new "event", :data => {}, :connection => connection, :channel => 5
         event.channel.should == :"5"
       end


### PR DESCRIPTION
### Channel Filters

Channel filters give the ability to intercept, modify, or cancel the broadcasting of events that are sent through channels.
### How to use it

I think it is best to explain by example. Lets say you have a chat based application where users can send messages to each other in different channels. But you want to make sure that all messages are logged.

Your controller might look something like this:

``` ruby
class ChatController < WebsocketRails::BaseController

  filter_for_channels :chat_room_one

  def new_message
    # store all messages to the database
    ChatLogger.create({user: current_user, channel: event.channel, message: message})

    # we can even alter the event object before it is sent back out
    event[:user_nickname] = current_user.nick_name
  end
end
```

and your client facing javascript/coffeescript might look something like this:

``` coffeescript
# create your main objects
dispatcher = new WebSocketRails('localhost:3000/websocket')
public_channel = dispatcher.subscribe('chat_room_one')

# listen for new chat messages
public_channel.bind 'new_message', newMessage()

# when the user clicks the send message button
$('#send_button').on 'click', sendMessage()

sendMessage: ->
    public_channel.trigger('new_message', {'message_body': $("#input_box").val()})

newMessage: (data) ->
    $('#chat_room').append("#{data.user_nickname} : #{data.message_body}")

```

As you can see here `filter_for_channels` gives us a "choke" point for your channel based messages. You can edit and alter the event object as you wish.

Also, `stop_event_propagation!` gives us a way to halt the channel event from being triggered back out to connected subscribers.

Lets see how that would work:

Your controller:

``` ruby
class WebsocketController < WebsocketRails::BaseController
  filter_for_channels :chat_room_one

  def new_message
    if message[:message_body].contains?('bad words')
      current_user.wash_mouth_out_with(soap)
      ChatLogger.create({user: current_user, channel: event.channel, message: message, bad_words: true})
      stop_event_propagation!
    else
      # continue on like normal
      ChatLogger.create({user: current_user, channel: event.channel, message: message})
      message[:user_nickname] = current_user.nickname
    end
  end
end
```
### Channel Events and how to catch them all

It might be a good idea to catch all events on any given channel.

Your controller might look something like this:

``` ruby
class WebsocketController < WebsocketRails::BaseController
  filter_for_channels :chat_room_one, :catch_all => :log_messages

  def log_messages
    ChatLogger.create({user: current_user, channel: event.channel, message: message})
  end
end
```
### Building your channels dynamically?

No problem, you can assign filters to channels after they're created. Similar to the `make_private` method: 

``` ruby
#available anywhere in your rails app
WebsocketRails[:some_dynamic_channel].filter_with(WebsocketController)
```

And for dynamic catch all methods: 

``` ruby
WebsocketRails[:some_dynamic_channel].filter_with(WebsocketController, catch_all: :log_messages)
```
