### PR TITLE
adding Process.daemon and Process.detach in websocket_rails starting tas...

### DIFF
--- a/lib/rails/tasks/websocket_rails.tasks
+++ b/lib/rails/tasks/websocket_rails.tasks
@@ -10,9 +10,11 @@ namespace :websocket_rails do
     warn_if_standalone_not_enabled!
 
     if options[:daemonize]
-      fork do
+      pid = fork do
+        Process.daemon
         Thin::Controllers::Controller.new(options).start
       end
+      Process.detach(pid)
     else
         Thin::Controllers::Controller.new(options).start
     end


### PR DESCRIPTION
In websocket_rails start server task added Process.detach to the father process and Process.daemon to the son.

In order to run it thought a capistrano deploy script :-)
