### PR TITLE
add window._pong_data to make pong data available

### DIFF
--- a/lib/assets/javascripts/websocket_rails/websocket_rails.js.coffee
+++ b/lib/assets/javascripts/websocket_rails/websocket_rails.js.coffee
@@ -137,7 +137,8 @@ class @WebSocketRails
     (typeof(WebSocket) == "function" or typeof(WebSocket) == "object")
 
   pong: =>
-    pong = new WebSocketRails.Event( ['websocket_rails.pong', {}, @_conn?.connection_id] )
+    data = window._pong_data || {}
+    pong = new WebSocketRails.Event( ['websocket_rails.pong', data, @_conn?.connection_id] )
     @_conn.trigger pong
 
   connection_stale: =>


### PR DESCRIPTION
Allow to send extra data to the pong event to track active connections.  Use case: to use with an expiring key in Redis for active connection and on the pong, use the info in the _pong_data to extend the key.  This way we are no longer depending on the connected/disconnected event to keep track of active status but have a far more reliable way via Redis.
