### PR TITLE
Rescue from PidFileNotFound in stop_server task

### DIFF
--- a/lib/rails/tasks/websocket_rails.tasks
+++ b/lib/rails/tasks/websocket_rails.tasks
@@ -30,7 +30,11 @@ namespace :websocket_rails do
 
     warn_if_standalone_not_enabled!
 
-    Thin::Controllers::Controller.new(options).stop
+    begin
+      Thin::Controllers::Controller.new(options).stop
+    rescue Thin::PidFileNotFound
+      puts "No PID file found for Websocket Rails Standalone Server"
+    end
   end
 end
 


### PR DESCRIPTION
When attempting to restart the standalone server by running the
stop_server then start_server tasks an exception is raised if the
server isn’t already running.  When running this via Capistrano it
aborts the whole deploy.  Rescuing and printing a message seems much
more forgiving.
