### PR TITLE
Don't clear subscribers if channel is already private

### DIFF
--- a/lib/websocket_rails/channel.rb
+++ b/lib/websocket_rails/channel.rb
@@ -44,7 +44,7 @@ module WebsocketRails
     end
 
     def make_private
-      unless config.keep_subscribers_when_private?
+      unless @private or config.keep_subscribers_when_private?
         @subscribers.clear
       end
       @private = true


### PR DESCRIPTION
It fixes problem when you can't use private channels at all.
See https://github.com/websocket-rails/websocket-rails/issues/247#issuecomment-56827830 for details.
