### PR TITLE
Bug fixed in Access-Control-Allow-Origin for standalone mode

### DIFF
--- a/lib/websocket_rails/connection_adapters/http.rb
+++ b/lib/websocket_rails/connection_adapters/http.rb
@@ -21,8 +21,10 @@ module WebsocketRails
 
         define_deferrable_callbacks
 
-        origin = "#{request.protocol}#{request.raw_host_with_port}"
-        @headers.merge!({'Access-Control-Allow-Origin' => origin}) if WebsocketRails.config.allowed_origins.include?(origin)
+        if WebsocketRails.config.allowed_origins.present?
+          @headers.merge!({'Access-Control-Allow-Origin' => Array(WebsocketRails.config.allowed_origins).join(",")})
+        end
+
         # IE < 10.0 hack
         # XDomainRequest will not bubble up notifications of download progress in the first 2kb of the response
         # http://blogs.msdn.com/b/ieinternals/archive/2010/04/06/comet-streaming-in-internet-explorer-with-xmlhttprequest-and-xdomainrequest.aspx


### PR DESCRIPTION
I tried to make a connection in rails project, from 127.0.0.1:3000 to 127.0.0.1:3001 in standalone mode and request.raw_host_with_port returns ip address with same port from standalone server. This behavior breaks connection from client using XHR. Furthermore, in my pull request i have added the possibility to add more than one domain in configuration array.

Regards