### PR TITLE
allow to replace the system namespace events

### DIFF
--- a/lib/assets/javascripts/websocket_rails/channel.js.coffee
+++ b/lib/assets/javascripts/websocket_rails/channel.js.coffee
@@ -17,9 +17,9 @@ class WebSocketRails.Channel
     @_token = undefined
     @_queue = []
     if @is_private
-      event_name = 'websocket_rails.subscribe_private'
+      event_name = WebSocketRails.SYSTEM_EVENTS_NAMESPACE_PREFIX + 'subscribe_private'
     else
-      event_name = 'websocket_rails.subscribe'
+      event_name = WebSocketRails.SYSTEM_EVENTS_NAMESPACE_PREFIX + 'subscribe'
 
     @connection_id = @_dispatcher._conn?.connection_id
     event = new WebSocketRails.Event( [event_name, {data: {channel: @name}}, @connection_id], @_success_launcher, @_failure_launcher)
@@ -27,7 +27,7 @@ class WebSocketRails.Channel
 
   destroy: ->
     if @connection_id == @_dispatcher._conn?.connection_id
-      event_name = 'websocket_rails.unsubscribe'
+      event_name = WebSocketRails.SYSTEM_EVENTS_NAMESPACE_PREFIX + 'unsubscribe'
       event =  new WebSocketRails.Event( [event_name, {data: {channel: @name}}, @connection_id] )
       @_dispatcher.trigger_event event
     @_callbacks = {}
@@ -47,7 +47,7 @@ class WebSocketRails.Channel
       @_dispatcher.trigger_event event
 
   dispatch: (event_name, message) ->
-    if event_name == 'websocket_rails.channel_token'
+    if event_name == WebSocketRails.SYSTEM_EVENTS_NAMESPACE_PREFIX + 'channel_token'
       @connection_id = @_dispatcher._conn?.connection_id
       @_token = message['token']
       @flush_queue()

--- a/lib/assets/javascripts/websocket_rails/event.js.coffee
+++ b/lib/assets/javascripts/websocket_rails/event.js.coffee
@@ -24,7 +24,7 @@ class WebSocketRails.Event
     typeof @result != 'undefined'
 
   is_ping: ->
-    @name == 'websocket_rails.ping'
+    @name == WebSocketRails.SYSTEM_EVENTS_NAMESPACE_PREFIX + 'ping'
 
   serialize: ->
       JSON.stringify [@name, @attributes()]

--- a/lib/assets/javascripts/websocket_rails/websocket_rails.js.coffee.erb
+++ b/lib/assets/javascripts/websocket_rails/websocket_rails.js.coffee.erb
@@ -20,6 +20,8 @@ Stop listening for new events from the server
   dispatcher.unbind('event')
 ###
 class @WebSocketRails
+  SYSTEM_EVENTS_NAMESPACE_PREFIX = '<%= WebsocketRails.config.system_namespace == :global ? "" : "#{WebsocketRails.config.system_namespace}." %>'
+
   constructor: (@url, @use_websockets = true) ->
     @callbacks = {}
     @channels  = {}
@@ -45,9 +47,9 @@ class @WebSocketRails
 
     @state     = 'disconnected'
 
-  # Reconnects the whole connection, 
+  # Reconnects the whole connection,
   # keeping the messages queue and its' connected channels.
-  # 
+  #
   # After successfull connection, this will:
   # - reconnect to all channels, that were active while disconnecting
   # - resend all events from which we haven't received any response yet
@@ -137,7 +139,7 @@ class @WebSocketRails
     (typeof(WebSocket) == "function" or typeof(WebSocket) == "object")
 
   pong: =>
-    pong = new WebSocketRails.Event( ['websocket_rails.pong', {}, @_conn?.connection_id] )
+    pong = new WebSocketRails.Event( [WebSocketRails.SYSTEM_EVENTS_NAMESPACE_PREFIX + 'pong', {}, @_conn?.connection_id] )
     @_conn.trigger pong
 
   connection_stale: =>

--- a/lib/websocket_rails/channel.rb
+++ b/lib/websocket_rails/channel.rb
@@ -76,10 +76,11 @@ module WebsocketRails
       options = {
         :channel => @name,
         :data => {:token => token},
-        :connection => connection
+        :connection => connection,
+        :namespace => WebsocketRails.config.system_namespace
       }
       info 'sending token'
-      Event.new('websocket_rails.channel_token', options).trigger
+      Event.new('channel_token', options).trigger
     end
 
     def send_data(event)

--- a/lib/websocket_rails/configuration.rb
+++ b/lib/websocket_rails/configuration.rb
@@ -134,6 +134,14 @@ module WebsocketRails
       @standalone_port = port
     end
 
+    def system_namespace
+      @system_namespace ||= :websocket_rails
+    end
+
+    def system_namespace=(system_namespace)
+      @system_namespace = system_namespace
+    end
+
     def thin_options
       @thin_options ||= thin_defaults
     end

--- a/lib/websocket_rails/event.rb
+++ b/lib/websocket_rails/event.rb
@@ -19,7 +19,7 @@ module WebsocketRails
     end
 
     def new_on_ping(connection)
-      Event.new :ping, :data => {}, :connection => connection, :namespace => :websocket_rails
+      Event.new :ping, :data => {}, :connection => connection, :namespace => WebsocketRails.config.system_namespace
     end
 
     def new_on_invalid_event_received(connection,data=nil)
@@ -155,7 +155,11 @@ module WebsocketRails
     end
 
     def is_internal?
-      namespace.include?(:websocket_rails)
+      namespace.include?(WebsocketRails.config.system_namespace) ||
+        (
+          (WebsocketRails.config.system_namespace == :global) &&
+          ["subscribe_private", "subscribe", "unsubscribe", "channel_token", "ping", "pong"].include?(name)
+        )
     end
 
     def should_propagate?

--- a/lib/websocket_rails/internal_events.rb
+++ b/lib/websocket_rails/internal_events.rb
@@ -2,10 +2,18 @@ module WebsocketRails
   class InternalEvents
     def self.events
       Proc.new do
-        namespace :websocket_rails do
+        subscribes = Proc.new do
           subscribe :pong, :to => InternalController, :with_method => :do_pong
           subscribe :subscribe, :to => InternalController, :with_method => :subscribe_to_channel
           subscribe :unsubscribe, :to => InternalController, :with_method => :unsubscribe_to_channel
+        end
+
+        if WebsocketRails.config.system_namespace == :global
+          subscribes.call
+        else
+          namespace WebsocketRails.config.system_namespace do
+            subscribes.call
+          end
         end
       end
     end


### PR DESCRIPTION
allow to replace the system namespace events from websocket_rails to another symbol, including :global