### PR TITLE
Require rails environment in rake task

### DIFF
--- a/lib/rails/tasks/websocket_rails.tasks
+++ b/lib/rails/tasks/websocket_rails.tasks
@@ -1,6 +1,6 @@
 namespace :websocket_rails do
   desc 'Start the WebsocketRails standalone server.'
-  task :start_server do
+  task :start_server => :environment do
     require "thin"
     load "#{Rails.root}/config/initializers/websocket_rails.rb"
     load "#{Rails.root}/config/events.rb"


### PR DESCRIPTION
Have seen websocket rails initialiser not being taken into account when running the rake task.