### PR TITLE
Use failure_message/failure_message_when_negated rspec matchers

### DIFF
--- a/lib/spec_helpers/matchers/route_matchers.rb
+++ b/lib/spec_helpers/matchers/route_matchers.rb
@@ -30,11 +30,11 @@ RSpec::Matchers.define :be_routed_to do |target|
     WebsocketRails::SpecHelpers.verify_route event, target, true
   end
 
-  failure_message_for_should do |event|
+  failure_message do |event|
     "expected event #{event.name} to be routed to target #{target}"
   end
 
-  failure_message_for_should_not do |event|
+  failure_message_when_negated do |event|
     "expected event #{event.name} not to be routed to target #{target}"
   end
 
@@ -50,11 +50,11 @@ RSpec::Matchers.define :be_routed_only_to do |target|
     WebsocketRails::SpecHelpers.verify_route event, target, false
   end
 
-  failure_message_for_should do |event|
+  failure_message do |event|
     "expected event #{event.name} to be routed only to target #{target}"
   end
 
-  failure_message_for_should_not do |event|
+  failure_message_when_negated do |event|
     "expected event #{event.name} not to be routed only to target #{target}"
   end
 

--- a/lib/spec_helpers/matchers/trigger_matchers.rb
+++ b/lib/spec_helpers/matchers/trigger_matchers.rb
@@ -55,12 +55,12 @@ RSpec::Matchers.define :trigger_message do |data|
     WebsocketRails::SpecHelpers.verify_trigger event, data, nil
   end
 
-  failure_message_for_should do |event|
+  failure_message do |event|
     "expected #{event.encoded_name} to trigger message#{WebsocketRails::SpecHelpers.expected_data_for_spec_message data}, " +
         "instead it #{WebsocketRails::SpecHelpers.actual_for_spec_message event, nil}"
   end
 
-  failure_message_for_should_not do |event|
+  failure_message_when_negated do |event|
     "expected #{event.encoded_name} not to trigger message#{WebsocketRails::SpecHelpers.expected_data_for_spec_message data}"
   end
 
@@ -76,12 +76,12 @@ RSpec::Matchers.define :trigger_success_message do |data|
     WebsocketRails::SpecHelpers.verify_trigger event, data, true
   end
 
-  failure_message_for_should do |event|
+  failure_message do |event|
     "expected #{event.encoded_name} to trigger success message#{WebsocketRails::SpecHelpers.expected_data_for_spec_message data}, "+
         "instead it #{WebsocketRails::SpecHelpers.actual_for_spec_message event, true}"
   end
 
-  failure_message_for_should_not do |event|
+  failure_message_when_negated do |event|
     "expected #{event.encoded_name} not to trigger success message#{WebsocketRails::SpecHelpers.expected_data_for_spec_message data}"
   end
 
@@ -97,12 +97,12 @@ RSpec::Matchers.define :trigger_failure_message do |data|
     WebsocketRails::SpecHelpers.verify_trigger event, data, false
   end
 
-  failure_message_for_should do |event|
+  failure_message do |event|
     "expected #{event.encoded_name} to trigger failure message#{WebsocketRails::SpecHelpers.expected_data_for_spec_message data}, " +
         "instead it #{WebsocketRails::SpecHelpers.actual_for_spec_message event, true}"
   end
 
-  failure_message_for_should_not do |event|
+  failure_message_when_negated do |event|
     "expected #{event.encoded_name} not to trigger failure message#{WebsocketRails::SpecHelpers.expected_data_for_spec_message data}"
   end
 


### PR DESCRIPTION
Gets rid of the deprecation warnings
````
`failure_message_for_should_not` is deprecated. Use `failure_message_when_negated` instead. 
Called from ~/.rbenv/versions/2.1.6/lib/ruby/gems/2.1.0/gems/websocket-rails-0.7.0/lib/spec_helpers/matchers/route_matchers.rb:37:in `block in <top (required)>'.

`failure_message_for_should` is deprecated. Use `failure_message` instead.
 Called from ~/.rbenv/versions/2.1.6/lib/ruby/gems/2.1.0/gems/websocket-rails-0.7.0/lib/spec_helpers/matchers/route_matchers.rb:33:in `block in <top (required)>'.
````