### PR TITLE
add support for synchronize without authenticate of current_user

### DIFF
--- a/lib/generators/websocket_rails/install/templates/websocket_rails.rb
+++ b/lib/generators/websocket_rails/install/templates/websocket_rails.rb
@@ -22,6 +22,9 @@ WebsocketRails.setup do |config|
   # * Requires Redis.
   config.synchronize = false
 
+	# Change to true to enable synchronize without authentize
+  config.synchronize_without_auth = false
+
   # Prevent Thin from daemonizing (default is true)
   # config.daemonize = false
 

--- a/lib/websocket-rails.rb
+++ b/lib/websocket-rails.rb
@@ -17,6 +17,10 @@ module WebsocketRails
       config.synchronize == true || config.standalone == true
     end
 
+    def synchronize_without_auth?
+      config.synchronize == true and config.synchronize_without_auth == true
+    end
+
     def standalone?
       config.standalone == true
     end

--- a/lib/websocket_rails/connection_adapters.rb
+++ b/lib/websocket_rails/connection_adapters.rb
@@ -123,10 +123,16 @@ module WebsocketRails
 
       def user
         return unless user_connection?
+
+				return { id: user_identifier } if WebsocketRails.synchronize_without_auth?
+
         controller_delegate.current_user
       end
 
       def user_identifier
+
+				return id if WebsocketRails.synchronize_without_auth?
+
         @user_identifier ||= begin
           identifier = WebsocketRails.config.user_identifier
 


### PR DESCRIPTION
#### Why I changed code.
I was trying to use ws-rails in standalone mode without authenticate the user, with the logic of `WebsocketRails`,  the synchronize will not save user to global. I will not get client connection with `WebsocketRails.users[id]`.