### PR TITLE
Lock faye-websocket gem dependency to 0.10.0.

### DIFF
--- a/lib/websocket_rails/version.rb
+++ b/lib/websocket_rails/version.rb
@@ -1,3 +1,3 @@
 module WebsocketRails
-  VERSION = "0.7.0"
+  VERSION = "0.7.1"
 end

--- a/websocket-rails.gemspec
+++ b/websocket-rails.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rails"
   s.add_dependency "rack"
-  s.add_dependency "faye-websocket"
+  s.add_dependency "faye-websocket", "0.10.0"
   s.add_dependency "thin"
   s.add_dependency "redis"
   s.add_dependency "hiredis"


### PR DESCRIPTION
Ultimately, whatever issues going on with this gem needs to be resolved so we can update faye-websocket to 0.10.4, but until that gets resolved, we should at least have the current dependencies set correctly.
