### PR TITLE
Fix for issue #238 - as_json w/out params

### DIFF
--- a/lib/websocket_rails/event.rb
+++ b/lib/websocket_rails/event.rb
@@ -122,7 +122,7 @@ module WebsocketRails
       @namespace    = validate_namespace( options[:namespace] || namespace )
     end
 
-    def as_json
+    def as_json(options = nil)
       [
         encoded_name,
         {

--- a/lib/websocket_rails/version.rb
+++ b/lib/websocket_rails/version.rb
@@ -1,3 +1,3 @@
 module WebsocketRails
-  VERSION = "0.7.0"
+  VERSION = "0.7.1"
 end


### PR DESCRIPTION
Adding default empty params to as_json on Event as we were running into this ActiveSupport issue on Rails 4.
