### PR TITLE
Rails Controller Delegator configuration

### DIFF
--- a/lib/generators/websocket_rails/install/templates/websocket_rails.rb
+++ b/lib/generators/websocket_rails/install/templates/websocket_rails.rb
@@ -60,4 +60,10 @@ WebsocketRails.setup do |config|
   # List here the origin domains allowed to perform the request.
   # config.allowed_origins = ['http://localhost:3000']
 
+  # Controller class that support 'current_user' method.
+  # Default WebsocketRails::DelegationController inherits ApplicationController.
+  # Use it if your ApplicationController doesn't implements 'current_user' and 
+  # you implements it in another controller
+  # config.delegation_controller_class = WebsocketRails::DelegationController
+
 end

--- a/lib/websocket_rails/configuration.rb
+++ b/lib/websocket_rails/configuration.rb
@@ -17,6 +17,14 @@ module WebsocketRails
       @user_class = klass
     end
 
+    def delegation_controller_class
+      @delegation_controller_class ||= WebsocketRails::DelegationController
+    end
+
+    def delegation_controller_class=(klass)
+      @delegation_controller_class = klass
+    end
+
     def keep_subscribers_when_private?
       @keep_subscribers_when_private ||= false
     end

--- a/lib/websocket_rails/connection_adapters.rb
+++ b/lib/websocket_rails/connection_adapters.rb
@@ -39,7 +39,7 @@ module WebsocketRails
         @connected  = true
         @queue      = EventQueue.new
         @data_store = DataStore::Connection.new(self)
-        @delegate   = WebsocketRails::DelegationController.new
+        @delegate   = WebsocketRails.config.delegation_controller_class.new
         @delegate.instance_variable_set(:@_env, request.env)
         @delegate.instance_variable_set(:@_request, request)
 


### PR DESCRIPTION
WebsocketRails use a Rails controller delegator to retrieve current_user (works nicely with Devise)
That patch enable to customize that delegator, which by default is a class that inherits ApplicationController
