### PR TITLE
Solves #388, connection problems with latest faye-websocket version.

### DIFF
--- a/lib/websocket_rails/connection_adapters/web_socket.rb
+++ b/lib/websocket_rails/connection_adapters/web_socket.rb
@@ -12,6 +12,7 @@ module WebsocketRails
         @connection.onmessage = method(:on_message)
         @connection.onerror   = method(:on_error)
         @connection.onclose   = method(:on_close)
+        @connection.rack_response
         EM.next_tick do
           on_open
         end


### PR DESCRIPTION
The gem `faye-websocket` has an example on the [github site](https://github.com/faye/faye-websocket-ruby#handling-websocket-connections-in-rack) where it calls `ws.rack_response` to return an async (non-blocking) Rack response. This pull request does exactly the same for `websocket-rails` gem.

**Tested and working with `faye-websocket` 0.10.4. Solves issue #388!**

``` ruby
# Faye-websocket example
require 'faye/websocket'

App = lambda do |env|
  if Faye::WebSocket.websocket?(env)
    ws = Faye::WebSocket.new(env)

    ws.on :message do |event|
      ws.send(event.data)
    end

    ws.on :close do |event|
      p [:close, event.code, event.reason]
      ws = nil
    end

    # Return async Rack response
    ws.rack_response

  else
    # Normal HTTP request
    [200, {'Content-Type' => 'text/plain'}, ['Hello']]
  end
end
```
