### PR TITLE
CL-27081, require redis file before to fix undefined deprecate! method error

### DIFF
--- a/lib/websocket_rails/connection_adapters/web_socket.rb
+++ b/lib/websocket_rails/connection_adapters/web_socket.rb
@@ -12,6 +12,7 @@ module WebsocketRails
         @connection.onmessage = method(:on_message)
         @connection.onerror   = method(:on_error)
         @connection.onclose   = method(:on_close)
+        @connection.rack_response
         EM.next_tick do
           on_open
         end

--- a/lib/websocket_rails/synchronization.rb
+++ b/lib/websocket_rails/synchronization.rb
@@ -1,5 +1,5 @@
-require "redis/connection/synchrony"
 require "redis"
+require "redis/connection/synchrony"
 require "redis/connection/ruby"
 
 module WebsocketRails

--- a/lib/websocket_rails/synchronization.rb
+++ b/lib/websocket_rails/synchronization.rb
@@ -62,6 +62,7 @@ module WebsocketRails
         Rails.logger.info '^' * 100
         Rails.logger.info 'Publishing event'
         Rails.logger.info '^' * 100
+        binding.pry
         event.server_token = server_token
         Redis.new(redis).publish "websocket_rails.events", event.serialize
       end.resume
@@ -85,6 +86,7 @@ module WebsocketRails
               Rails.logger.info '$' * 100
               Rails.logger.info 'Subscribe response'
               Rails.logger.info '$' * 100
+              binding.pry
               event = Event.new_from_json(encoded_event, nil)
 
               # Do nothing if this is the server that sent this event.

--- a/lib/websocket_rails/synchronization.rb
+++ b/lib/websocket_rails/synchronization.rb
@@ -59,9 +59,9 @@ module WebsocketRails
 
     def publish(event)
       Fiber.new do
-        puts '^' * 100
-        puts 'Publishing event'
-        puts '^' * 100
+        Rails.logger.info '^' * 100
+        Rails.logger.info 'Publishing event'
+        Rails.logger.info '^' * 100
         event.server_token = server_token
         Redis.new(redis).publish "websocket_rails.events", event.serialize
       end.resume
@@ -82,9 +82,9 @@ module WebsocketRails
           fiber_redis.subscribe "websocket_rails.events" do |on|
 
             on.message do |_, encoded_event|
-              puts '$' * 100
-              puts 'Subscribe response'
-              puts '$' * 100
+              Rails.logger.info '$' * 100
+              Rails.logger.info 'Subscribe response'
+              Rails.logger.info '$' * 100
               event = Event.new_from_json(encoded_event, nil)
 
               # Do nothing if this is the server that sent this event.

--- a/lib/websocket_rails/synchronization.rb
+++ b/lib/websocket_rails/synchronization.rb
@@ -59,9 +59,9 @@ module WebsocketRails
 
     def publish(event)
       Fiber.new do
-        Rails.logger.info '^' * 100
+        Rails.logger.info '*' * 100
         Rails.logger.info 'Publishing event'
-        Rails.logger.info '^' * 100
+        Rails.logger.info '*' * 100
         binding.pry
         event.server_token = server_token
         Redis.new(redis).publish "websocket_rails.events", event.serialize

--- a/lib/websocket_rails/synchronization.rb
+++ b/lib/websocket_rails/synchronization.rb
@@ -83,10 +83,10 @@ module WebsocketRails
           # while sidekiq requires hiredis driver to work with
           if ENV['POD_TYPE'] == 'background' || Sidekiq.server?
             # hiredis
-            fiber_redis = Redis.connect(WebsocketRails.config.redis_options.merge(driver: :hiredis))
+            fiber_redis = Redis.new(WebsocketRails.config.redis_options.merge(driver: :hiredis))
           else
             # synchrony
-            fiber_redis = Redis.connect(WebsocketRails.config.redis_options)
+            fiber_redis = Redis.new(WebsocketRails.config.redis_options)
           end
 
           @server_token = generate_server_token

--- a/lib/websocket_rails/synchronization.rb
+++ b/lib/websocket_rails/synchronization.rb
@@ -59,6 +59,9 @@ module WebsocketRails
 
     def publish(event)
       Fiber.new do
+        puts '^' * 100
+        puts 'Publishing event'
+        puts '^' * 100
         event.server_token = server_token
         Redis.new(redis).publish "websocket_rails.events", event.serialize
       end.resume
@@ -79,6 +82,9 @@ module WebsocketRails
           fiber_redis.subscribe "websocket_rails.events" do |on|
 
             on.message do |_, encoded_event|
+              puts '$' * 100
+              puts 'Subscribe response'
+              puts '$' * 100
               event = Event.new_from_json(encoded_event, nil)
 
               # Do nothing if this is the server that sent this event.

--- a/lib/websocket_rails/synchronization.rb
+++ b/lib/websocket_rails/synchronization.rb
@@ -81,12 +81,12 @@ module WebsocketRails
         synchro = Fiber.new do
           # since puma is EM based it requires synchrony driver to work with it
           # while sidekiq requires hiredis driver to work with
-          if ENV['POD_TYPE'] == 'WEB'
-            # synchrony
-            fiber_redis = Redis.connect(WebsocketRails.config.redis_options)
-          elsif ENV['POD_TYPE'] == 'background'
+          if ENV['POD_TYPE'] == 'background' || Sidekiq.server?
             # hiredis
             fiber_redis = Redis.connect(WebsocketRails.config.redis_options.merge(driver: :hiredis))
+          else
+            # synchrony
+            fiber_redis = Redis.connect(WebsocketRails.config.redis_options)
           end
 
           @server_token = generate_server_token

--- a/lib/websocket_rails/synchronization.rb
+++ b/lib/websocket_rails/synchronization.rb
@@ -70,11 +70,12 @@ module WebsocketRails
 
     def synchronize!
       unless @synchronizing
-        @server_token = generate_server_token
-        register_server(@server_token)
-
         synchro = Fiber.new do
           fiber_redis = Redis.connect(WebsocketRails.config.redis_options)
+
+          @server_token = generate_server_token
+          register_server(@server_token)
+
           fiber_redis.subscribe "websocket_rails.events" do |on|
 
             on.message do |_, encoded_event|

--- a/lib/websocket_rails/synchronization.rb
+++ b/lib/websocket_rails/synchronization.rb
@@ -60,7 +60,7 @@ module WebsocketRails
     def publish(event)
       Fiber.new do
         event.server_token = server_token
-        redis.publish "websocket_rails.events", event.serialize
+        Redis.new(redis).publish "websocket_rails.events", event.serialize
       end.resume
     end
 


### PR DESCRIPTION
https://jira.dev.e2open.com/jira/browse/CL-27081

In order to upgrade `sidekiq`, we had to update `redis` gem. Redis gem has some changes in `synchrony.rb` file because of which an error was getting thrown as `undefined method deprecate! for Redis:Class`. This websocket gem also requires this file. And hence we need to require `redis` file first before using `synchrony` file.